### PR TITLE
use symbolic links instead of hard links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,11 @@ Config files
 ## Structure
 This repo replicates the structure of `~/`.
 
-Each file is hard linked from it's correspondent in `~/`.
-
-As a result both files point to the same inode and changes in either file will be available in the other
+Each file in `~/` is meant to be symlinked to a config here.
 
 ## Initilizing
 A new system can be initialized to use these config files by running the `link` script.
 
 The script will create links from the repo files to the corresponding locations in `~/`.
 
-**Note that any existing files in ~/ will be overwritten by their repo counterparts.**
+**Users will be prompted before overwites, backups are reccomended**

--- a/link
+++ b/link
@@ -1,15 +1,18 @@
 #!/bin/bash
 
 
-# Creates hard links from config files
+# Creates symbolic links from config files
 
 # The first argument is the original file,
-# the second is the hard link
+# the second is the link
 
-# This will OVERWRITE any existing config files
-# in ~/ at the paths specified below with the versions
-# contained in this repo
+# In the event a file already exists
+# at the desired link location, the user
+# will be prompted to overwrite
 
+
+# Absolute path to repo
+DIR="$(dirname "$(readlink -f "$0")")"
 
 # i3
-ln -f .config/i3/config ~/.config/i3/config
+ln --symbolic --interactive ${DIR}/.config/i3/config ~/.config/i3/config


### PR DESCRIPTION
- Use symbolic links

With hard links, the link needs to be re-established when initializing new files. Since the file will be present on its branch, but not on master. When master is checked out to pull in the new changes, the file will be 'removed' and then recreated when the pull is complete. As a result the link will be broken and need to be recreated as well.

Since the symbolic link just points to the source file, it does not matter what happens to it.