### PR TITLE
set PS1 to dir name with unicode arrow

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -6,7 +6,7 @@
 [[ $- != *i* ]] && return
 
 alias ls='ls --color=auto'
-PS1='[\u@\h \W]\$ '
+PS1='\W ❯ '
 
 # NVM
 source /usr/share/nvm/init-nvm.sh


### PR DESCRIPTION
Example (~/): `~ ❯`