### PR TITLE
Update/i3status battery

### DIFF
--- a/.config/i3status/config
+++ b/.config/i3status/config
@@ -23,6 +23,7 @@ wireless _first_ {
 
 battery all {
         format = "%status %percentage %remaining"
+        last_full_capacity = true
 }
 
 memory {

--- a/.config/i3status/config
+++ b/.config/i3status/config
@@ -24,6 +24,7 @@ wireless _first_ {
 battery all {
         format = "%status %percentage %remaining"
         last_full_capacity = true
+        integer_battery_capacity = true
 }
 
 memory {


### PR DESCRIPTION
- `last_full_capacity = true` shows battery percentage based on the last time the battery was fully charged. It does not take into account the battery degradation and as a result will fill to 100% as opposed to 70% when 'full'.

- `integer_battery_capacity` = true` shows the value as an integer instead of a decimal

https://i3wm.org/i3status/manpage.html#_battery